### PR TITLE
refactor(model): standardize entity field naming convention

### DIFF
--- a/src/main/java/pys/core/rest/kotlin/model/ClienteMovimiento.kt
+++ b/src/main/java/pys/core/rest/kotlin/model/ClienteMovimiento.kt
@@ -19,7 +19,7 @@ data class ClienteMovimiento(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "clave")
-    var clienteMovimientoId: Long? = null,
+    var clientemovimientoId: Long? = null,
 
     @Column(name = "mcl_neg_id")
     var negocioId: Int? = null,
@@ -35,17 +35,17 @@ data class ClienteMovimiento(
 
     @Column(name = "fechacomprob")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
-    var fechaComprobante: OffsetDateTime? = null,
+    var fechacomprobante: OffsetDateTime? = null,
 
     @Column(name = "mcl_fechavenc")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
-    var fechaVencimiento: OffsetDateTime? = null,
+    var fechavencimiento: OffsetDateTime? = null,
 
     @Column(name = "prefijo")
-    var puntoVenta: Int = 0,
+    var puntoventa: Int = 0,
 
     @Column(name = "nrocomprob")
-    var numeroComprobante: Long = 0L,
+    var numerocomprobante: Long = 0L,
 
     @Column(name = "importe")
     var importe: BigDecimal = BigDecimal.ZERO,
@@ -54,13 +54,13 @@ data class ClienteMovimiento(
     var cancelado: BigDecimal = BigDecimal.ZERO,
 
     @Column(name = "netosindescuento")
-    var netoSinDescuento: BigDecimal = BigDecimal.ZERO,
+    var netosindescuento: BigDecimal = BigDecimal.ZERO,
 
     @Column(name = "neto")
     var neto: BigDecimal = BigDecimal.ZERO,
 
     @Column(name = "netocancelado")
-    var netoCancelado: BigDecimal = BigDecimal.ZERO,
+    var netocancelado: BigDecimal = BigDecimal.ZERO,
 
     @Column(name = "montoiva")
     var iva: BigDecimal = BigDecimal.ZERO,
@@ -75,13 +75,13 @@ data class ClienteMovimiento(
     var anulada: Byte = 0,
 
     @Column(name = "tipocompro")
-    var tipoComprobante: String = "",
+    var tipocomprobante: String = "",
 
     @Column(name = "mcl_letras")
     var letras: String = "",
 
     @Column(name = "mcl_iva")
-    var alicuotaIva: BigDecimal = BigDecimal.ZERO,
+    var alicuotaiva: BigDecimal = BigDecimal.ZERO,
 
     @Column(name = "mcl_observaciones")
     var observaciones: String = "",
@@ -90,7 +90,7 @@ data class ClienteMovimiento(
     var cae: String = "",
 
     @Column(name = "mcl_caevenc")
-    var caeVencimiento: String = "",
+    var caevencimiento: String = "",
 
     @Column(name = "mcl_barras")
     var barras: String = "",

--- a/src/main/java/pys/core/rest/kotlin/repository/ClienteMovimientoRepository.kt
+++ b/src/main/java/pys/core/rest/kotlin/repository/ClienteMovimientoRepository.kt
@@ -8,11 +8,11 @@ import java.util.Optional
 @Repository
 interface ClienteMovimientoRepository : JpaRepository<ClienteMovimiento, Long> {
 
-    fun findAllByClienteIdAndComprobanteIdInOrderByClienteMovimientoIdDesc(
+    fun findAllByClienteIdAndComprobanteIdInOrderByClientemovimientoIdDesc(
         clienteId: Long,
         comprobanteIds: List<Int>
     ): List<ClienteMovimiento?>?
 
-    fun findByClienteMovimientoId(clienteMovimientoId: Long): Optional<ClienteMovimiento?>?
+    fun findByClientemovimientoId(clienteMovimientoId: Long): Optional<ClienteMovimiento?>?
 
 }

--- a/src/main/java/pys/core/rest/service/ClienteMovimientoService.java
+++ b/src/main/java/pys/core/rest/service/ClienteMovimientoService.java
@@ -24,11 +24,11 @@ public class ClienteMovimientoService {
     public List<ClienteMovimiento> findAllAsociables(Long clienteId) {
         List<Integer> comprobanteIds = comprobanteService.findAllAsociables().stream()
                 .map(Comprobante::getComprobanteId).collect(Collectors.toList());
-        return repository.findAllByClienteIdAndComprobanteIdInOrderByClienteMovimientoIdDesc(clienteId, comprobanteIds);
+        return repository.findAllByClienteIdAndComprobanteIdInOrderByClientemovimientoIdDesc(clienteId, comprobanteIds);
     }
 
     public ClienteMovimiento findByClienteMovimientoId(Long clienteMovimientoId) {
-        return Objects.requireNonNull(repository.findByClienteMovimientoId(clienteMovimientoId))
+        return Objects.requireNonNull(repository.findByClientemovimientoId(clienteMovimientoId))
                 .orElseThrow(() -> new ClienteMovimientoException(clienteMovimientoId));
     }
 

--- a/src/main/java/pys/core/rest/service/facade/FacturaPdfService.java
+++ b/src/main/java/pys/core/rest/service/facade/FacturaPdfService.java
@@ -88,7 +88,7 @@ public class FacturaPdfService {
         ClienteMovimiento clienteMovimiento = clienteMovimientoService.findByClienteMovimientoId(clientemovimientoId);
         Cliente cliente = clienteService.findByClienteId(clienteMovimiento.getClienteId());
         Electronico electronico = electronicoService.findByUnique(clienteMovimiento.getComprobanteId(),
-                clienteMovimiento.getPuntoVenta(), clienteMovimiento.getNumeroComprobante());
+                clienteMovimiento.getPuntoventa(), clienteMovimiento.getNumerocomprobante());
 
         ClienteMovimiento clienteMovimientoAsociado = null;
         ComprobanteAfip comprobanteAfipAsociado = null;
@@ -344,7 +344,7 @@ public class FacturaPdfService {
             int lineas = 24;
 
             for (ArticuloMovimiento articulomovimiento : articuloMovimientoService
-                    .findAllByClientemovimientoId(clienteMovimiento.getClienteMovimientoId())) {
+                    .findAllByClientemovimientoId(clienteMovimiento.getClientemovimientoId())) {
                 lineas--;
                 table = new PdfPTable(5);
                 table.setWidthPercentage(100);
@@ -415,9 +415,9 @@ public class FacturaPdfService {
                     observaciones += comprobanteAfipAsociado.getLabel();
                 }
                 if (clienteMovimientoAsociado != null) {
-                    observaciones += clienteMovimientoAsociado.getTipoComprobante()
-                            + String.format("%04d", clienteMovimientoAsociado.getPuntoVenta()) + "-"
-                            + String.format("%08d", clienteMovimientoAsociado.getNumeroComprobante());
+                    observaciones += clienteMovimientoAsociado.getTipocomprobante()
+                            + String.format("%04d", clienteMovimientoAsociado.getPuntoventa()) + "-"
+                            + String.format("%08d", clienteMovimientoAsociado.getNumerocomprobante());
                 }
             }
             observaciones += clienteMovimiento.getObservaciones();


### PR DESCRIPTION
BREAKING CHANGE: Update field names to follow consistent naming pattern

- Change camelCase fields to lowercase in ClienteMovimiento entity

- Update repository method names to match new field names

- Modify service layer to use updated field names

- Update PDF generation service to use new naming convention

Closes #13